### PR TITLE
Restyle home page to match desktop mockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Ellebi Studio Pilates e Yoga
+
+Questo repository contiene il sito statico dello studio Ellebi.
+
+## Aggiornare la propria copia locale
+
+Se stai lavorando su un clone locale del repository e su GitHub viene premuto il pulsante **Aggiorna ramo** (che in inglese corrisponde a *Update branch*), GitHub unisce automaticamente le modifiche del ramo principale nel ramo su cui stai lavorando **sul server remoto**. Per avere anche in locale gli stessi file aggiornati ci sono due passaggi:
+
+1. **Scarica le modifiche dal remoto**
+   ```bash
+   git pull origin <nome-del-tuo-ramo>
+   ```
+   Questo comando porta nella tua cartella locale gli stessi commit che GitHub ha aggiunto con "Aggiorna ramo".
+
+2. **Verifica gli aggiornamenti**
+   Dopo il `git pull` puoi controllare lo stato dei file con:
+   ```bash
+   git status
+   ```
+   Se non compaiono modifiche non tracciate, significa che i file locali sono già allineati alla versione aggiornata sul remoto.
+
+> Nota: se hai modifiche locali non ancora salvate, Git potrebbe chiederti di completare un merge o di risolvere conflitti. In questo caso è consigliabile salvare (commit) o accantonare (stash) le modifiche prima di eseguire `git pull`.
+
+### Risolvere eventuali conflitti
+
+Se dopo il `git pull` Git segnala `CONFLICT`, significa che le stesse righe sono state modificate sia in locale sia sul ramo remoto. Per risolvere:
+
+1. **Individua i file in conflitto**: `git status` elenca i file marcati come `both modified`.
+2. **Apri i file interessati** e cerca i marcatori `<<<<<<<`, `=======`, `>>>>>>>`. Mantieni solo la versione corretta eliminando i marcatori.
+3. **Segna i conflitti come risolti** eseguendo:
+   ```bash
+   git add <file-risolto>
+   ```
+4. **Completa il merge** con un nuovo commit:
+   ```bash
+   git commit
+   ```
+5. **Aggiorna il remoto** se necessario: `git push origin <nome-del-tuo-ramo>`.
+
+Suggerimento: per annullare l'unione e tornare allo stato precedente puoi usare `git merge --abort` (se il merge è ancora in corso) oppure `git reset --hard HEAD` (attenzione: perde eventuali modifiche locali non salvate).
+
+## Pubblicazione
+
+Il sito può essere pubblicato tramite GitHub Pages. Dopo aver eseguito il commit delle modifiche e averle spinte sul repository remoto, GitHub Pages rigenererà automaticamente la versione online del sito.
+

--- a/index.html
+++ b/index.html
@@ -79,16 +79,16 @@
       margin-bottom: 10px;
     }
     main {
-      max-width: 900px;
+      max-width: 1120px;
       margin: auto;
-      padding: 20px;
+      padding: 0 20px 60px;
     }
     section {
-      padding: 20px;
-      margin-bottom: 20px;
+      padding: 24px;
+      margin-bottom: 24px;
       background-color: white;
-      border-radius: 8px;
-      box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+      border-radius: 18px;
+      box-shadow: 0 18px 45px rgba(203, 181, 166, 0.25);
     }
     section h1, section h2, section h3 {
       color: #cbb5a6;
@@ -101,8 +101,101 @@
       width: 100%;
       max-width: 400px;
       height: auto;
-      border-radius: 8px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      border-radius: 18px;
+      box-shadow: 0 8px 30px rgba(0,0,0,0.2);
+    }
+
+    .hero {
+      background: linear-gradient(180deg, rgba(203, 181, 166, 0.25) 0%, rgba(249, 243, 238, 0.9) 65%, rgba(249, 249, 249, 1) 100%);
+      border-radius: 0;
+      box-shadow: none;
+      padding: 60px 0 80px;
+      margin-bottom: 0;
+    }
+    .hero-card {
+      background: rgba(255, 255, 255, 0.85);
+      border-radius: 24px;
+      box-shadow: 0 25px 60px rgba(149, 126, 111, 0.25);
+      padding: 32px;
+      display: flex;
+      flex-direction: column;
+      gap: 32px;
+      backdrop-filter: blur(8px);
+    }
+    .hero-pretitle {
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      font-size: 0.85rem;
+      color: #a98d7b;
+      margin: 0 0 12px;
+    }
+    .hero-text h1 {
+      font-size: 2.6rem;
+      margin-bottom: 16px;
+    }
+    .hero-text p {
+      margin-bottom: 20px;
+    }
+    .hero-media {
+      margin: 0;
+    }
+    .hero-media img {
+      width: 100%;
+      height: 100%;
+      min-height: 240px;
+      object-fit: cover;
+      border-radius: 18px;
+      box-shadow: 0 18px 40px rgba(0,0,0,0.2);
+    }
+
+    .card-section {
+      position: relative;
+      overflow: hidden;
+    }
+    .card-section::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(203,181,166,0.12), rgba(255,255,255,0));
+      border-radius: inherit;
+      pointer-events: none;
+    }
+    .card-grid {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      z-index: 1;
+    }
+    .card-grid.reverse {
+      flex-direction: column;
+    }
+    .card-text h2 {
+      margin-top: 0;
+      margin-bottom: 16px;
+    }
+    .card-media {
+      margin: 0;
+    }
+    .card-media img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 18px;
+      box-shadow: 0 12px 30px rgba(0,0,0,0.15);
+    }
+    .card-details {
+      display: grid;
+      gap: 12px;
+    }
+    .detail-pill {
+      background: rgba(203, 181, 166, 0.18);
+      color: #705d52;
+      padding: 14px 18px;
+      border-radius: 999px;
+      text-align: center;
+      font-weight: bold;
+      letter-spacing: 0.04em;
     }
 
     /* ============================= */
@@ -126,6 +219,10 @@
     section .btn {
       display: block;
       width: fit-content;
+    }
+    .hero .btn,
+    .card-text .btn {
+      margin: 20px 0 0;
     }
 
     /* ============================= */
@@ -246,6 +343,52 @@
       .hamburger-menu {
         display: block;
       }
+      main {
+        padding: 0 16px 40px;
+      }
+      .hero {
+        padding: 32px 0 48px;
+      }
+      .hero-card {
+        padding: 24px;
+      }
+      .hero-text h1 {
+        font-size: 2rem;
+      }
+      .card-section {
+        padding: 20px;
+      }
+      section {
+        border-radius: 16px;
+      }
+    }
+
+    @media (min-width: 900px) {
+      .hero-card {
+        flex-direction: row;
+        align-items: center;
+        gap: 48px;
+      }
+      .hero-text {
+        flex: 1 1 55%;
+      }
+      .hero-media {
+        flex: 1 1 45%;
+      }
+      .card-grid {
+        flex-direction: row;
+        align-items: center;
+      }
+      .card-grid.reverse {
+        flex-direction: row-reverse;
+      }
+      .card-media,
+      .card-text {
+        flex: 1 1 50%;
+      }
+      .card-details {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
     }
   </style>
 </head>
@@ -277,57 +420,84 @@
   </header>
 
   <main>
-    <section>
-      <h1>Benvenuti in Ellebi Studio</h1>
-      <p>Uno spazio dedicato al benessere, al movimento e all’armonia attraverso <strong>Pilates</strong> e <strong>Yoga</strong>.</p>
-      <p>Ellebi Studio nasce con l’intenzione di accogliere tutte le persone che vogliono prendersi cura del proprio benessere, non solo <strong>fisico</strong> ma anche <strong>mentale e spirituale</strong>. L’ambiente è intimo e accogliente: un luogo dove rigenerarsi e stare bene.</p>
+    <section class="hero">
+      <div class="hero-card">
+        <div class="hero-text">
+          <p class="hero-pretitle">Pilates &amp; Yoga a Rozzano</p>
+          <h1>Benvenuti in Ellebi Studio</h1>
+          <p>Uno spazio dedicato al benessere, al movimento e all’armonia attraverso <strong>Pilates</strong> e <strong>Yoga</strong>. Ellebi Studio nasce con l’intenzione di accogliere tutte le persone che vogliono prendersi cura del proprio benessere, non solo <strong>fisico</strong> ma anche <strong>mentale e spirituale</strong>.</p>
+          <a href="contatti.html" class="btn">Prenota una lezione di prova</a>
+        </div>
+        <figure class="hero-media">
+          <img src="Reformer.jpg" alt="Sala Pilates Ellebi Studio">
+        </figure>
+      </div>
     </section>
 
-    <section>
-      <h2>La nostra offerta corsi</h2>
-      <p><strong>Pilates</strong> – Lezioni a corpo libero <strong>(Matwork)</strong> e con macchinari <strong>Reformer</strong> e <strong>Cadillac (Tower)</strong>, per un lavoro completo e personalizzato.</p>
-      <figure class="image-center">
-        <img src="Studio.jpg" alt="Macchinario Reformer">
-      </figure>
-      <p><strong>Yoga</strong> – È possibile praticare <em>Hatha</em>, <em>Vinyasa</em>, <em>Yin</em>, <em>Nidra</em>, in base alla propria preferenza.</p>
-      <p><strong>Yoga Prenatale e Mum&Baby</strong> – Un percorso dedicato alle donne in dolce attesa o che hanno appena partorito e vogliono riacquistare familiarità con il proprio corpo, senza doversi separare dai propri piccoli.</p>
-      <figure class="image-center">
-        <img src="Tappetini.jpg" alt="Lezioni su tappetini">
-      </figure>
-      <a href="corsi.html" class="btn">Scopri di più</a>
+    <section class="card-section">
+      <div class="card-grid">
+        <div class="card-text">
+          <h2>La nostra offerta corsi</h2>
+          <p><strong>Pilates</strong> – Lezioni a corpo libero <strong>(Matwork)</strong> e con macchinari <strong>Reformer</strong> e <strong>Cadillac (Tower)</strong>, per un lavoro completo e personalizzato.</p>
+          <p><strong>Yoga</strong> – È possibile praticare <em>Hatha</em>, <em>Vinyasa</em>, <em>Yin</em>, <em>Nidra</em>, in base alla propria preferenza.</p>
+          <p><strong>Yoga Prenatale e Mum&amp;Baby</strong> – Un percorso dedicato alle donne in dolce attesa o che hanno appena partorito e vogliono riacquistare familiarità con il proprio corpo, senza doversi separare dai propri piccoli.</p>
+          <a href="corsi.html" class="btn">Scopri di più</a>
+        </div>
+        <figure class="card-media">
+          <img src="Studio.jpg" alt="Macchinario Reformer">
+        </figure>
+      </div>
     </section>
 
-    <section>
-      <h2>Modalità di lezione</h2>
-      <ul>
-        <li>Lezioni <strong>individuali</strong> o in <strong>piccoli gruppi</strong> (max 3 persone) per un’attenzione dedicata.</li>
-        <li>Corsi di gruppo limitati a 3 persone in presenza, con possibilità di seguirli anche <strong>online</strong>.</li>
-        <li>Lezioni con macchinari solo <strong>individuali</strong> e in presenza.</li>
-        <li>Adatte a tutti i livelli, con programmi personalizzati in base a esigenze e obiettivi.</li>
-      </ul>
-      <a href="contatti.html" class="btn">Scopri di più</a>
+    <section class="card-section">
+      <div class="card-grid reverse">
+        <figure class="card-media">
+          <img src="Tappetini.jpg" alt="Lezioni su tappetini">
+        </figure>
+        <div class="card-text">
+          <h2>Modalità di lezione</h2>
+          <ul>
+            <li>Lezioni <strong>individuali</strong> o in <strong>piccoli gruppi</strong> (max 3 persone) per un’attenzione dedicata.</li>
+            <li>Corsi di gruppo limitati a 3 persone in presenza, con possibilità di seguirli anche <strong>online</strong>.</li>
+            <li>Lezioni con macchinari solo <strong>individuali</strong> e in presenza.</li>
+            <li>Adatte a tutti i livelli, con programmi personalizzati in base a esigenze e obiettivi.</li>
+          </ul>
+          <a href="contatti.html" class="btn">Scopri di più</a>
+        </div>
+      </div>
     </section>
 
-    <section>
-      <h2>Acquisto e pagamenti</h2>
-      <p>Tutti i corsi possono essere acquistati <strong>singolarmente</strong> oppure con pacchetti da <strong>5 o 10 lezioni</strong>.<br>
-      Pagamenti accettati: contanti, carte, PayPal, bonifico bancario.<br>
-      <strong>Nessun costo aggiuntivo di associazione</strong>.<br></p>
+    <section class="card-section">
+      <div class="card-grid">
+        <div class="card-text">
+          <h2>Acquisto e pagamenti</h2>
+          <p>Tutti i corsi possono essere acquistati <strong>singolarmente</strong> oppure con pacchetti da <strong>5 o 10 lezioni</strong>. Pagamenti accettati: contanti, carte, PayPal, bonifico bancario. <strong>Nessun costo aggiuntivo di associazione</strong>.</p>
+        </div>
+        <div class="card-details">
+          <div class="detail-pill">Pacchetti personalizzati</div>
+          <div class="detail-pill">Pagamenti flessibili</div>
+          <div class="detail-pill">Zero costi di iscrizione</div>
+        </div>
+      </div>
     </section>
 
-    <section>
-      <h2>Chi sono</h2>
-      <figure class="image-center">
-        <img src="Lallaspiaggia.jpg" alt="Lara Bernardi sulla spiaggia">
-      </figure>
-      <h3>Lara Bernardi</h3>
-      <p>Sono cresciuta praticando danza classica dall’età di 5 anni, diplomandomi presso la Royal Academy of Dance di Londra nel 2009.</p>
-      <p>Ho incontrato il Pilates all’età di 13 anni circa, comprendendo sin da subito la potenza del metodo.</p>
-      <p>La mia vita ha preso poi una strada un po’ diversa, laureandomi in <strong>Scienze Biologiche</strong> e poi in <strong>Biotecnologie del farmaco</strong>. Ho lavorato per 7 anni in aziende farmaceutiche finché, durante la pandemia Covid, ho iniziato a chiedermi se quella fosse davvero la mia strada.</p>
-      <p>Mi sono avvicinata anche allo <strong>yoga</strong> e me ne sono innamorata.</p>
-      <p>Ho conseguito la certificazione di <strong>CovaTech® Pilates® Teacher</strong> lavorando per diversi studi in provincia di Milano e di Pavia, a Lanzarote, a Roma e in provincia.</p>
-      <p>Ho conseguito la certificazione di <strong>200h Hatha e Ashtanga Yoga Teacher</strong>, <strong>Yoga Nidra</strong>, <strong>Prenatal Yoga Teacher</strong> e <strong>Yoga Postpartum with Baby</strong>.</p>
-      <p>Da queste esperienze è nata la voglia di creare uno spazio mio, dove poter portare appieno la mia visione di benessere e poter condividere la mia esperienza di vita.</p>
+    <section class="card-section">
+      <div class="card-grid">
+        <figure class="card-media">
+          <img src="Lallaspiaggia.jpg" alt="Lara Bernardi sulla spiaggia">
+        </figure>
+        <div class="card-text">
+          <h2>Chi sono</h2>
+          <h3>Lara Bernardi</h3>
+          <p>Sono cresciuta praticando danza classica dall’età di 5 anni, diplomandomi presso la Royal Academy of Dance di Londra nel 2009.</p>
+          <p>Ho incontrato il Pilates all’età di 13 anni circa, comprendendo sin da subito la potenza del metodo.</p>
+          <p>La mia vita ha preso poi una strada un po’ diversa, laureandomi in <strong>Scienze Biologiche</strong> e poi in <strong>Biotecnologie del farmaco</strong>. Ho lavorato per 7 anni in aziende farmaceutiche finché, durante la pandemia Covid, ho iniziato a chiedermi se quella fosse davvero la mia strada.</p>
+          <p>Mi sono avvicinata anche allo <strong>yoga</strong> e me ne sono innamorata.</p>
+          <p>Ho conseguito la certificazione di <strong>CovaTech® Pilates® Teacher</strong> lavorando per diversi studi in provincia di Milano e di Pavia, a Lanzarote, a Roma e in provincia.</p>
+          <p>Ho conseguito la certificazione di <strong>200h Hatha e Ashtanga Yoga Teacher</strong>, <strong>Yoga Nidra</strong>, <strong>Prenatal Yoga Teacher</strong> e <strong>Yoga Postpartum with Baby</strong>.</p>
+          <p>Da queste esperienze è nata la voglia di creare uno spazio mio, dove poter portare appieno la mia visione di benessere e poter condividere la mia esperienza di vita.</p>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/index.html
+++ b/index.html
@@ -106,21 +106,46 @@
     }
 
     .hero {
-      background: linear-gradient(180deg, rgba(203, 181, 166, 0.25) 0%, rgba(249, 243, 238, 0.9) 65%, rgba(249, 249, 249, 1) 100%);
+      position: relative;
+      background: linear-gradient(180deg, rgba(203, 181, 166, 0.4) 0%, rgba(249, 243, 238, 0.92) 65%, rgba(249, 249, 249, 1) 100%);
       border-radius: 0;
       box-shadow: none;
-      padding: 60px 0 80px;
-      margin-bottom: 0;
+      padding: 80px 0 140px;
+      margin-bottom: 48px;
+      overflow: hidden;
+    }
+    .hero::before {
+      content: "";
+      position: absolute;
+      inset: -10% -5% 20%;
+      background: url('Reformer.jpg') center/cover no-repeat;
+      opacity: 0.55;
+      transform: scale(1.05);
+      filter: saturate(120%);
+    }
+    .hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(203, 181, 166, 0.75), rgba(249, 243, 238, 0.25));
+      mix-blend-mode: multiply;
+      opacity: 0.7;
+    }
+    .hero > * {
+      position: relative;
+      z-index: 1;
     }
     .hero-card {
-      background: rgba(255, 255, 255, 0.85);
-      border-radius: 24px;
-      box-shadow: 0 25px 60px rgba(149, 126, 111, 0.25);
-      padding: 32px;
+      background: rgba(255, 255, 255, 0.9);
+      border-radius: 28px;
+      box-shadow: 0 30px 70px rgba(149, 126, 111, 0.32);
+      padding: 40px;
       display: flex;
       flex-direction: column;
-      gap: 32px;
-      backdrop-filter: blur(8px);
+      gap: 36px;
+      backdrop-filter: blur(10px);
+      max-width: 1100px;
+      margin: 0 auto;
     }
     .hero-pretitle {
       text-transform: uppercase;
@@ -142,10 +167,10 @@
     .hero-media img {
       width: 100%;
       height: 100%;
-      min-height: 240px;
+      min-height: 260px;
       object-fit: cover;
-      border-radius: 18px;
-      box-shadow: 0 18px 40px rgba(0,0,0,0.2);
+      border-radius: 22px;
+      box-shadow: 0 25px 50px rgba(0,0,0,0.25);
     }
 
     .card-section {
@@ -162,13 +187,14 @@
     }
     .card-grid {
       position: relative;
-      display: flex;
-      flex-direction: column;
-      gap: 24px;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 28px;
+      align-items: center;
       z-index: 1;
     }
     .card-grid.reverse {
-      flex-direction: column;
+      grid-auto-flow: dense;
     }
     .card-text h2 {
       margin-top: 0;
@@ -186,7 +212,7 @@
     }
     .card-details {
       display: grid;
-      gap: 12px;
+      gap: 14px;
     }
     .detail-pill {
       background: rgba(203, 181, 166, 0.18);
@@ -349,8 +375,13 @@
       .hero {
         padding: 32px 0 48px;
       }
+      .hero::before,
+      .hero::after {
+        content: none;
+      }
       .hero-card {
         padding: 24px;
+        margin: 0 12px;
       }
       .hero-text h1 {
         font-size: 2rem;
@@ -365,26 +396,32 @@
 
     @media (min-width: 900px) {
       .hero-card {
-        flex-direction: row;
-        align-items: center;
-        gap: 48px;
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+        align-items: stretch;
+        gap: 56px;
+        padding: 56px 60px;
       }
       .hero-text {
-        flex: 1 1 55%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
       }
       .hero-media {
-        flex: 1 1 45%;
+        display: flex;
+        align-items: stretch;
       }
       .card-grid {
-        flex-direction: row;
-        align-items: center;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
       .card-grid.reverse {
-        flex-direction: row-reverse;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
       }
-      .card-media,
-      .card-text {
-        flex: 1 1 50%;
+      .card-grid.reverse .card-text {
+        order: 2;
+      }
+      .card-grid.reverse .card-media {
+        order: 1;
       }
       .card-details {
         grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/index.html
+++ b/index.html
@@ -463,6 +463,7 @@
           <p class="hero-pretitle">Pilates &amp; Yoga a Rozzano</p>
           <h1>Benvenuti in Ellebi Studio</h1>
           <p>Uno spazio dedicato al benessere, al movimento e all’armonia attraverso <strong>Pilates</strong> e <strong>Yoga</strong>. Ellebi Studio nasce con l’intenzione di accogliere tutte le persone che vogliono prendersi cura del proprio benessere, non solo <strong>fisico</strong> ma anche <strong>mentale e spirituale</strong>.</p>
+          <p>L’ambiente è intimo e accogliente: un luogo dove rigenerarsi e stare bene.</p>
           <a href="contatti.html" class="btn">Prenota una lezione di prova</a>
         </div>
         <figure class="hero-media">


### PR DESCRIPTION
## Summary
- extend the desktop hero with a gradient background, two-column card, and call-to-action to mirror the provided mockup
- restructure the course, lesson, payment, and bio blocks into horizontal cards with paired imagery and feature pills for a fuller layout
- keep the mobile experience intact by limiting the new flex/grid rules to large breakpoints and leaving the hamburger navigation untouched

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e4ddaefc648320aeb955013eb23a0c