### PR TITLE
Use absolute paths for favicons and apple-touch-icon

### DIFF
--- a/contatti.html
+++ b/contatti.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ellebi Studio Pilates e Yoga - Contatti</title>
   <link rel="stylesheet" href="style.css?v=3">
-  <link rel="icon" href="favicon.ico" sizes="any">
-  <link rel="icon" href="favicon-96x96.png" type="image/png" sizes="96x96">
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon-96x96.png" type="image/png" sizes="96x96">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 </head>
 <body class="page-contatti">
   <header class="hero-header hero-contatti">

--- a/corsi.html
+++ b/corsi.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ellebi Studio Pilates e Yoga - Corsi</title>
   <link rel="stylesheet" href="style.css?v=3">
-  <link rel="icon" href="favicon.ico" sizes="any">
-  <link rel="icon" href="favicon-96x96.png" type="image/png" sizes="96x96">
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon-96x96.png" type="image/png" sizes="96x96">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 </head>
 <body class="page-corsi">
   <header class="hero-header hero-corsi">

--- a/eventi.html
+++ b/eventi.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ellebi Studio Pilates e Yoga - Eventi</title>
   <link rel="stylesheet" href="style.css?v=3">
-  <link rel="icon" href="favicon.ico" sizes="any">
-  <link rel="icon" href="favicon-96x96.png" type="image/png" sizes="96x96">
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon-96x96.png" type="image/png" sizes="96x96">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 </head>
 <body class="page-eventi">
   <header class="hero-header hero-eventi">

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Ellebi Studio Pilates e Yoga - Home</title>
   <link rel="stylesheet" href="style.css?v=3">
-  <link rel="icon" href="favicon.ico" sizes="any">
-  <link rel="icon" href="favicon-96x96.png" type="image/png" sizes="96x96">
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon-96x96.png" type="image/png" sizes="96x96">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 </head>
 <body class="page-home">
   <header class="hero-header hero-home">


### PR DESCRIPTION
### Motivation
- Ensure the site icon is discoverable by browsers and crawlers by serving favicon and Apple touch icon from absolute paths at the site root.

### Description
- Updated icon links in `index.html`, `corsi.html`, `contatti.html`, and `eventi.html` to use absolute paths (`/favicon.ico`, `/favicon-96x96.png`, `/apple-touch-icon.png`).

### Testing
- No automated tests were run because this is a static HTML change; files were inspected and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e491a7ec832daf1fe672bd6a7b85)